### PR TITLE
fix postinst scripts to run without errors related to nidas-daq files no longer installed

### DIFF
--- a/ads-daq/DEBIAN/control
+++ b/ads-daq/DEBIAN/control
@@ -6,7 +6,7 @@ Version: x.y
 Section: science
 Priority: optional
 Architecture: all
-Depends: eol-daq, gpsd, chrony, pps-tools, cmigits-nidas
+Depends: eol-daq, gpsd, chrony, pps-tools, cmigits-nidas, systemd
 Suggests: ethtool
 Maintainer: Chris Webster <cjw@ucar.edu>
 Homepage: https://github.com/ncareol/embedded-daq

--- a/ads-daq/DEBIAN/postinst
+++ b/ads-daq/DEBIAN/postinst
@@ -322,8 +322,9 @@ EOD
     sed -r -i -e 's/^START_DAEMON=.*true.*/START_DAEMON="false"/' $cf
     sed -r -i -e 's/^USBAUTO=.*true.*/USBAUTO="false"/' $cf
 
-    if ! md5sum -c --status $tmpfile; then
-        /etc/init.d/chrony restart
+    if ! md5sum -c --status $tmpfile && \
+        systemctl is-active --quiet chrony > /dev/null 2>&1; then
+        systemctl restart chrony
     fi
 
     cf=/etc/crontab
@@ -405,7 +406,10 @@ run-parts --report /etc/cron.daily" $cf
             if systemctl is-enabled $timer > /dev/null; then
                 echo "disabling $timer"
                 systemctl disable $timer
-                systemctl stop $timer
+                # no need to stop a timer that is not running
+                if systemctl is-active --quiet $timer > /dev/null 2>&1; then
+                    systemctl stop $timer
+                fi
             fi
         done
     fi

--- a/ads-daq/DEBIAN/postinst
+++ b/ads-daq/DEBIAN/postinst
@@ -57,7 +57,8 @@ if [ "$1" = configure ]; then
     update-rc.d bluetooth disable S 2 3 4 5 >& /dev/null || :
     # update-rc.d -f bluetooth remove
 
-    update-rc.d dsm defaults
+    # dsm init script no longer used or installed
+    # update-rc.d dsm defaults
 
     update-rc.d emerald disable S 2 3 4 5 >& /dev/null || :
     # update-rc.d -f emerald remove
@@ -83,9 +84,13 @@ if [ "$1" = configure ]; then
 	echo "192.168.84.10	timeserver" >> $cf
     fi
 
-    # crude hack: if ads.conf in /etc/rsyslog.d is new, restart rsyslog
+    # crude hack: if ads.conf in /etc/rsyslog.d is new, restart rsyslog, but
+    # only if rsyslog is running.  this also avoids trying to restart rsyslog
+    # on a container when systemd is not running.
     if [ $(find /etc/rsyslog.d -name ads.conf -ctime -1 | wc -w ) -gt 0 ]; then
-        /etc/init.d/rsyslog restart
+        if systemctl is-active --quiet rsyslog > /dev/null 2>&1; then
+            systemctl restart rsyslog
+        fi
     fi
     # create crontab for root
     if ! crontab -l > /dev/null; then
@@ -407,7 +412,9 @@ run-parts --report /etc/cron.daily" $cf
 
     # Nuke uio48 lines in nidas.conf - they belong in uio48.conf
     cf=/etc/modprobe.d/nidas.conf
-    sed -i -r -e '/uio48/d' -e '/.*Vortex.*GPIO/d' $cf
+    if [ -f $cf ]; then
+        sed -i -r -e '/uio48/d' -e '/.*Vortex.*GPIO/d' $cf
+    fi
 fi
 
 exit 0

--- a/eol-daq/DEBIAN/control
+++ b/eol-daq/DEBIAN/control
@@ -6,7 +6,7 @@ Version: x.y
 Section: science
 Priority: optional
 Depends: i2c-tools, usbutils, ifplugd, rsync, minicom, setserial, gawk,
-        openssh-server, curl
+         openssh-server, curl, rsyslog
 Architecture: all
 Maintainer: Gordon Maclean <maclean@ucar.edu>
 Homepage: https://github.com/ncareol/embedded-daq

--- a/eol-daq/DEBIAN/postinst
+++ b/eol-daq/DEBIAN/postinst
@@ -282,7 +282,9 @@ $!b                 # not
             sed -E -i -e 's/(HandleLidSwitch=).*/\1ignore/' $tcf
         if ! diff -q $cf $tcf > /dev/null; then
             cp $tcf $cf
-            systemctl restart systemd-logind.service
+            if systemctl is-active --quiet systemd-logind.service > /dev/null 2>&1; then
+                systemctl restart systemd-logind.service
+            fi
         fi
     fi
 fi

--- a/eol-daq/DEBIAN/postinst
+++ b/eol-daq/DEBIAN/postinst
@@ -253,8 +253,10 @@ $!b                 # not
         ' $cf
     fi
 
-    # restart rsyslog if we've changed anything
-    $rssyslog && /etc/init.d/rsyslog restart
+    # restart rsyslog if we've changed anything, and if rsyslog is running
+    if $rssyslog && systemctl is-active --quiet rsyslog > /dev/null 2>&1; then
+        systemctl restart rsyslog
+    fi
 
     # Set HandleLidSwitch=ignore in /etc/systemd/logind.conf
     # On vortex:


### PR DESCRIPTION
With the changes on this branch, I can build and install the eol-daq and ads-daq packages successfully in a vortex container.  I haven't tested the changes on actual vortex hardware.

It is possible to run systemd inside a container with podman, eg [How to run systemd in a container](https://developers.redhat.com/blog/2019/04/24/how-to-run-systemd-in-a-container#), which would allow for better testing of the postinst scripts, but I haven't got that working yet.
